### PR TITLE
Fix BsonClassMap initialization on .NET Core 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: csharp
-solution: Repository.Mongo.sln
-install:
-  - nuget restore Repository.Mongo.sln
-  - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
-script:
-  - msbuild /p:Configuration=Release Repository.Mongo.sln
-  - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Repository.Mongo.Tests/bin/Release/Repository.Mongo.Tests.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: csharp
+solution: Repository.Mongo.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: csharp
 solution: Repository.Mongo.sln
+install:
+  - nuget restore Repository.Mongo.sln
+  - nuget install xunit.runners -Version 1.9.2 -OutputDirectory testrunner
+script:
+  - msbuild /p:Configuration=Release Repository.Mongo.sln
+  - mono ./testrunner/xunit.runners.1.9.2/tools/xunit.console.clr4.exe ./Repository.Mongo.Tests/bin/Release/Repository.Mongo.Tests.dll

--- a/README.md
+++ b/README.md
@@ -61,40 +61,48 @@ Each method has multiple overloads, read method summary for additional parameter
 ```csharp
 	UserRepository repo = new UserRepository("mongodb://localhost/sample")
 
-	//Get
+	// Get
 	User user = repo.Get("58a18d16bc1e253bb80a67c9");
 
-	//Insert
+	// Insert
 	User item = new User(){
 		Username = "username",
 		Password = "password"
 	};
 	repo.Insert(item);
 
-	//Update
-	//single property
+	// Update
+	// Single property
 	repo.Update(item, i => i.Username, "newUsername");
 
-	//multiple property
-	//Updater has many methods like Inc, Push, CurrentDate, etc.
+	// Multiple property
+	// Updater has many methods like Inc, Push, CurrentDate, etc.
 	var update1 = Updater.Set(i => i.Username, "oldUsername");
 	var update2 = Updater.Set(i => i.Password, "newPassword");
 	repo.Update(item, update1, update2);
 
-	//all entity
+	// All entity
 	item.Username = "someUsername";
 	repo.Replace(item);
 
-	//Delete
+	// Delete
 	repo.Delete(item);
 
-	//Queries - all queries has filter, order and paging features
+	// Queries - all queries has filter, order and paging features
 	var first = repo.First();
 	var last = repo.Last();
 	var search = repo.Find(i => i.Username == "username");
 	var allItems = repo.FindAll();
 
-	//Utils
-	var count = repo.Count();
+	// Utils
 	var any = repo.Any(i => i.Username.Contains("user"));
+	
+	// Count
+	// Get number of filtered documents
+	var count = repo.Count(p => p.Age > 20);
+	
+	// EstimatedCount
+	// Get number of all documents
+	var count = repo.EstimatedCount();
+	
 ```

--- a/README.md
+++ b/README.md
@@ -11,47 +11,47 @@ Repository pattern for MongoDB with extended features
 #### Model
 You don't need to create a model, but if you are doing so you need to extend Entity
 ```csharp
-	//if you are able to define your model
-	public class User : Entity
-	{
-		public string Username { get; set; }
-		public string Password { get; set; }
-	}
+//if you are able to define your model
+public class User : Entity 
+{
+    public string Username { get; set; }
+    public string Password { get; set; }
+}	
 ```
 
 #### Repository
 There are multiple base constructors, read summaries of others
 ```csharp
-	public class UserRepository : Repository<User>
-	{
-		public UserRepository(string connectionString) : base(connectionString) {}
+public class UserRepository : Repository<User> 
+{
+    public UserRepository (string connectionString) : base (connectionString) { }
 
-		//custom method
-		public User FindbyUsername(string username)
-		{
-			return First(i => i.Username == username);
-		}
-		
-		//custom method2
-		public void UpdatePassword(User item, string newPassword)
-		{
-			repo.Update(item, i => i.Password, newPassword);
-		}
-	}
+    //custom method
+    public User FindbyUsername (string username) 
+    {
+        return First (i => i.Username == username);
+    }
+
+    //custom method2
+    public void UpdatePassword (User item, string newPassword) 
+    {
+        repo.Update (item, i => i.Password, newPassword);
+    }
+}
 ```
 
 *If you want to create a repository for already defined non-entity model*
 ```csharp
-	public class UserRepository : Repository<Entity<User>>
-	{
-		public UserRepository(string connectionString) : base(connectionString) {}
+public class UserRepository : Repository<Entity<User>> 
+{
+    public UserRepository (string connectionString) : base (connectionString) { }
 
-		//custom method
-		public User FindbyUsername(string username)
-		{
-			return First(i => i.Content.Username == username);
-		}
-	}
+    //custom method
+    public User FindbyUsername (string username) 
+    {
+        return First (i => i.Content.Username == username);
+    }
+}	
 ```
 
 ### Usage
@@ -59,50 +59,50 @@ There are multiple base constructors, read summaries of others
 Each method has multiple overloads, read method summary for additional parameters
 
 ```csharp
-	UserRepository repo = new UserRepository("mongodb://localhost/sample")
+UserRepository repo = new UserRepository ("mongodb://localhost/sample")
 
-	// Get
-	User user = repo.Get("58a18d16bc1e253bb80a67c9");
+// Get
+User user = repo.Get ("58a18d16bc1e253bb80a67c9");
 
-	// Insert
-	User item = new User(){
-		Username = "username",
-		Password = "password"
-	};
-	repo.Insert(item);
+// Insert
+User item = new User () 
+{
+    Username = "username",
+    Password = "password"
+};
+repo.Insert (item);
 
-	// Update
-	// Single property
-	repo.Update(item, i => i.Username, "newUsername");
+// Update
+// Single property
+repo.Update (item, i => i.Username, "newUsername");
 
-	// Multiple property
-	// Updater has many methods like Inc, Push, CurrentDate, etc.
-	var update1 = Updater.Set(i => i.Username, "oldUsername");
-	var update2 = Updater.Set(i => i.Password, "newPassword");
-	repo.Update(item, update1, update2);
+// Multiple property
+// Updater has many methods like Inc, Push, CurrentDate, etc.
+var update1 = Updater.Set (i => i.Username, "oldUsername");
+var update2 = Updater.Set (i => i.Password, "newPassword");
+repo.Update (item, update1, update2);
 
-	// All entity
-	item.Username = "someUsername";
-	repo.Replace(item);
+// All entity
+item.Username = "someUsername";
+repo.Replace (item);
 
-	// Delete
-	repo.Delete(item);
+// Delete
+repo.Delete (item);
 
-	// Queries - all queries has filter, order and paging features
-	var first = repo.First();
-	var last = repo.Last();
-	var search = repo.Find(i => i.Username == "username");
-	var allItems = repo.FindAll();
+// Queries - all queries has filter, order and paging features
+var first = repo.First ();
+var last = repo.Last ();
+var search = repo.Find (i => i.Username == "username");
+var allItems = repo.FindAll ();
 
-	// Utils
-	var any = repo.Any(i => i.Username.Contains("user"));
-	
-	// Count
-	// Get number of filtered documents
-	var count = repo.Count(p => p.Age > 20);
-	
-	// EstimatedCount
-	// Get number of all documents
-	var count = repo.EstimatedCount();
-	
+// Utils
+var any = repo.Any (i => i.Username.Contains ("user"));
+
+// Count
+// Get number of filtered documents
+var count = repo.Count (p => p.Age > 20);
+
+// EstimatedCount
+// Get number of all documents
+var count = repo.EstimatedCount ();
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Visual Studio Team services](https://img.shields.io/vso/build/dissperltd/6c214d4e-3676-4b7d-b7fb-9d7079975c67/7.svg?style=flat-square)]()
+[![Build Status](https://dev.azure.com/doxalabs/Mongo%20Repository/_apis/build/status/fatihyildizhan.MongoRepository?branchName=master)](https://dev.azure.com/doxalabs/Mongo%20Repository/_build/latest?definitionId=20&branchName=master)
 [![Version](https://img.shields.io/nuget/v/Repository.Mongo.svg?style=flat-square)](https://www.nuget.org/packages/Repository.Mongo)
 [![Downloads](https://img.shields.io/nuget/dt/Repository.Mongo.svg?style=flat-square)](https://www.nuget.org/packages/Repository.Mongo)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://dev.azure.com/doxalabs/Mongo%20Repository/_apis/build/status/fatihyildizhan.MongoRepository?branchName=master)](https://dev.azure.com/doxalabs/Mongo%20Repository/_build/latest?definitionId=20&branchName=master)
+[![Build Status](https://dev.azure.com/doxalabs/Public%20DevOps%20Pipelines/_apis/build/status/fatihyildizhan.MongoRepository?branchName=master)](https://dev.azure.com/doxalabs/Public%20DevOps%20Pipelines/_build/latest?definitionId=20&branchName=master)
 [![Version](https://img.shields.io/nuget/v/Repository.Mongo.svg?style=flat-square)](https://www.nuget.org/packages/Repository.Mongo)
 [![Downloads](https://img.shields.io/nuget/dt/Repository.Mongo.svg?style=flat-square)](https://www.nuget.org/packages/Repository.Mongo)
 

--- a/Repository.Mongo.Tests/Repository.Mongo.Tests.csproj
+++ b/Repository.Mongo.Tests/Repository.Mongo.Tests.csproj
@@ -1,16 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Repository.Mongo/Database.cs
+++ b/Repository.Mongo/Database.cs
@@ -1,7 +1,9 @@
-﻿using MongoDB.Driver;
-using System;
-using Microsoft.Extensions.Configuration;
+﻿using System;
 using System.Reflection;
+// Nuget Microsoft
+using Microsoft.Extensions.Configuration;
+// Nuget MongoDB
+using MongoDB.Driver;
 
 namespace Repository.Mongo
 {

--- a/Repository.Mongo/Entity.cs
+++ b/Repository.Mongo/Entity.cs
@@ -1,6 +1,7 @@
-﻿using MongoDB.Bson;
+﻿using System;
+// Nuget MongoDB
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using System;
 
 namespace Repository.Mongo
 {

--- a/Repository.Mongo/IEntity.cs
+++ b/Repository.Mongo/IEntity.cs
@@ -1,6 +1,7 @@
-﻿using MongoDB.Bson;
+﻿using System;
+// Nuget MongoDB
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
-using System;
 
 namespace Repository.Mongo
 {

--- a/Repository.Mongo/IRepository.cs
+++ b/Repository.Mongo/IRepository.cs
@@ -319,6 +319,19 @@ namespace Repository.Mongo
 
         #endregion Replace
 
+        #region FindOneAndUpdate
+
+        /// <summary>
+        /// Find by filter definition and update with update definition
+        /// </summary>
+        /// <param name="filter">filter definition</param>
+        /// <param name="update">update definition</param>
+        /// <param name="options">optional options like isUpsert</param>
+        /// <returns>returns T</returns>
+        T FindOneAndUpdate(FilterDefinition<T> filter, UpdateDefinition<T> update, FindOneAndUpdateOptions<T> options = null);
+
+        #endregion FindOneAndUpdate
+
         #region Update
 
         /// <summary>

--- a/Repository.Mongo/IRepository.cs
+++ b/Repository.Mongo/IRepository.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using System.Linq.Expressions;
 using System.Collections.Generic;
-// MongoDB
+// Nuget MongoDB
 using MongoDB.Driver;
 
 namespace Repository.Mongo

--- a/Repository.Mongo/IRepository.cs
+++ b/Repository.Mongo/IRepository.cs
@@ -448,58 +448,42 @@ namespace Repository.Mongo
         /// get number of filtered documents
         /// </summary>
         /// <param name="filter">expression filter</param>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCount instead.")]
+        /// <returns>returns the count of documents that match the query for a collection or view.</returns>
         long Count(Expression<Func<T, bool>> filter);
 
         /// <summary>
-        /// get number of filtered documents
+        /// get number of filtered documents async
         /// </summary>
         /// <param name="filter">expression filter</param>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCountAsync instead.")]
+        /// <returns>returns the count of documents that match the query for a collection or view.</returns>
         Task<long> CountAsync(Expression<Func<T, bool>> filter);
-
-        /// <summary>
-        /// get number of documents in collection
-        /// </summary>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCount instead.")]
-        long Count();
-
-        /// <summary>
-        /// get number of documents in collection
-        /// </summary>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCountAsync instead.")]
-        Task<long> CountAsync();
         #endregion Count
 
         #region EstimatedCount
         /// <summary>
-        /// get number of documents with options
+        /// get number of all documents in collection with options
         /// </summary>
         /// <param name="options">count options</param>
-        /// <returns>number of documents</returns>
+        /// <returns>returns the count of all documents in a collection or view with count options.</returns> 
         long EstimatedCount(EstimatedDocumentCountOptions options);
 
         /// <summary>
-        /// get number of documents with options
+        /// get number of all documents in collection with options
         /// </summary>
         /// <param name="options">count options</param>
-        /// <returns>number of documents</returns>
+        /// <returns>returns the count of all documents in a collection or view with count options.</returns> 
         Task<long> EstimatedCountAsync(EstimatedDocumentCountOptions options);
 
         /// <summary>
-        /// get number of documents in collection
+        /// get number of all documents in collection
         /// </summary>
-        /// <returns>number of documents</returns>
+        /// <returns>returns the count of all documents in a collection or view.</returns>
         long EstimatedCount();
 
         /// <summary>
-        /// get number of documents in collection
+        /// get number of all documents in collection
         /// </summary>
-        /// <returns>number of documents</returns>
+        /// <returns>returns the count of all documents in a collection or view.</returns>
         Task<long> EstimatedCountAsync();
         #endregion EstimatedCount
 

--- a/Repository.Mongo/IRepository.cs
+++ b/Repository.Mongo/IRepository.cs
@@ -1,8 +1,9 @@
-﻿using MongoDB.Driver;
-using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
+﻿using System;
 using System.Threading.Tasks;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+// MongoDB
+using MongoDB.Driver;
 
 namespace Repository.Mongo
 {
@@ -435,6 +436,7 @@ namespace Repository.Mongo
         /// </summary>
         /// <param name="filter">expression filter</param>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCount instead.")]
         long Count(Expression<Func<T, bool>> filter);
 
         /// <summary>
@@ -442,20 +444,51 @@ namespace Repository.Mongo
         /// </summary>
         /// <param name="filter">expression filter</param>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCountAsync instead.")]
         Task<long> CountAsync(Expression<Func<T, bool>> filter);
 
         /// <summary>
         /// get number of documents in collection
         /// </summary>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCount instead.")]
         long Count();
 
         /// <summary>
         /// get number of documents in collection
         /// </summary>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCountAsync instead.")]
         Task<long> CountAsync();
         #endregion Count
+
+        #region EstimatedCount
+        /// <summary>
+        /// get number of documents with options
+        /// </summary>
+        /// <param name="options">count options</param>
+        /// <returns>number of documents</returns>
+        long EstimatedCount(EstimatedDocumentCountOptions options);
+
+        /// <summary>
+        /// get number of documents with options
+        /// </summary>
+        /// <param name="options">count options</param>
+        /// <returns>number of documents</returns>
+        Task<long> EstimatedCountAsync(EstimatedDocumentCountOptions options);
+
+        /// <summary>
+        /// get number of documents in collection
+        /// </summary>
+        /// <returns>number of documents</returns>
+        long EstimatedCount();
+
+        /// <summary>
+        /// get number of documents in collection
+        /// </summary>
+        /// <returns>number of documents</returns>
+        Task<long> EstimatedCountAsync();
+        #endregion EstimatedCount
 
         #endregion Utils
     }

--- a/Repository.Mongo/Properties/AssemblyInfo.cs
+++ b/Repository.Mongo/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/Repository.Mongo/Repository.Mongo.csproj
+++ b/Repository.Mongo/Repository.Mongo.csproj
@@ -4,11 +4,11 @@
     <Description>Repository pattern for MongoDB</Description>
     <AssemblyTitle>Repository.Mongo</AssemblyTitle>
     <Authors>Usame Esendir</Authors>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net452;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Repository.Mongo</AssemblyName>
     <PackageId>Repository.Mongo</PackageId>
-    <PackageTags>mongo;repository;mongodb;</PackageTags>
+    <PackageTags>mongo;repository;mongodb;nosql;</PackageTags>
     <PackageReleaseNotes>New constructors to support more IoC options</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/esendir/MongoRepository</PackageProjectUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.9.1" />
-    <PackageReference Include="Polly" Version="6.0.1" />
+    <PackageReference Include="Polly" Version="5.9.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -42,11 +42,11 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD2_0;NET452</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_5;NET452;netstandard2.0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile></DocumentationFile>
+    <DocumentationFile>obj\Debug\netstandard1.5\Repository.Mongo.xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/Repository.Mongo/Repository.Mongo.csproj
+++ b/Repository.Mongo/Repository.Mongo.csproj
@@ -4,7 +4,7 @@
     <Description>Repository pattern for MongoDB</Description>
     <AssemblyTitle>Repository.Mongo</AssemblyTitle>
     <Authors>Usame Esendir</Authors>
-    <TargetFrameworks>netstandard1.5;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Repository.Mongo</AssemblyName>
     <PackageId>Repository.Mongo</PackageId>
@@ -29,10 +29,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.7.2" />
-    <PackageReference Include="Polly" Version="5.9.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.9.0-beta2" />
+    <PackageReference Include="Polly" Version="7.1.0" />
   </ItemGroup>
-
   
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
@@ -43,7 +42,11 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_5;NET45</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD2_0;NET452</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DocumentationFile>obj\Debug\netstandard2.0\Repository.Mongo.xml</DocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/Repository.Mongo/Repository.Mongo.csproj
+++ b/Repository.Mongo/Repository.Mongo.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.9.1" />
-    <PackageReference Include="Polly" Version="7.1.0" />
+    <PackageReference Include="Polly" Version="6.0.1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>obj\Debug\netstandard2.0\Repository.Mongo.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/Repository.Mongo/Repository.Mongo.csproj
+++ b/Repository.Mongo/Repository.Mongo.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.9.0-beta2" />
+    <PackageReference Include="MongoDB.Driver" Version="2.9.0" />
     <PackageReference Include="Polly" Version="7.1.0" />
   </ItemGroup>
   

--- a/Repository.Mongo/Repository.Mongo.csproj
+++ b/Repository.Mongo/Repository.Mongo.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.9.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.9.1" />
     <PackageReference Include="Polly" Version="7.1.0" />
   </ItemGroup>
   

--- a/Repository.Mongo/Repository.cs
+++ b/Repository.Mongo/Repository.cs
@@ -1,14 +1,16 @@
-﻿using Microsoft.Extensions.Configuration;
-using MongoDB.Driver;
-using Polly;
-using Polly.Retry;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using System.Linq.Expressions;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+// Polly
+using Polly;
+using Polly.Retry;
+// MongoDB
+using MongoDB.Driver;
 
 namespace Repository.Mongo
 {
@@ -193,7 +195,7 @@ namespace Repository.Mongo
                 return Task.Run(() =>
                 {
                     return Delete(id);
-                }); 
+                });
             });
         }
 
@@ -792,6 +794,7 @@ namespace Repository.Mongo
         /// </summary>
         /// <param name="filter">expression filter</param>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCount instead.")]
         public long Count(Expression<Func<T, bool>> filter)
         {
             return Retry(() =>
@@ -805,6 +808,7 @@ namespace Repository.Mongo
         /// </summary>
         /// <param name="filter">expression filter</param>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCountAsync instead.")]
         public Task<long> CountAsync(Expression<Func<T, bool>> filter)
         {
             return Retry(() =>
@@ -817,6 +821,7 @@ namespace Repository.Mongo
         /// get number of documents in collection
         /// </summary>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCount instead.")]
         public long Count()
         {
             return Retry(() =>
@@ -829,6 +834,7 @@ namespace Repository.Mongo
         /// get number of documents in collection
         /// </summary>
         /// <returns>number of documents</returns>
+        [Obsolete("Use EstimatedCountAsync instead.")]
         public Task<long> CountAsync()
         {
             return Retry(() =>
@@ -837,6 +843,58 @@ namespace Repository.Mongo
             });
         }
         #endregion Count
+
+        #region EstimatedCount
+        /// <summary>
+        /// get number of filtered documents
+        /// </summary>
+        /// <param name="options">count options</param>
+        /// <returns>number of documents</returns>        
+        public long EstimatedCount(EstimatedDocumentCountOptions options)
+        {
+            return Retry(() =>
+            {
+                return Collection.EstimatedDocumentCount(options);
+            });
+        }
+
+        /// <summary>
+        /// get number of filtered documents
+        /// </summary>
+        /// <param name="options">count options</param>
+        /// <returns>number of documents</returns>        
+        public Task<long> EstimatedCountAsync(EstimatedDocumentCountOptions options)
+        {
+            return Retry(() =>
+            {
+                return Collection.EstimatedDocumentCountAsync(options);
+            });
+        }
+
+        /// <summary>
+        /// get number of documents in collection
+        /// </summary>
+        /// <returns>number of documents</returns>
+        public long EstimatedCount()
+        {
+            return Retry(() =>
+            {
+                return Collection.EstimatedDocumentCount();
+            });
+        }
+
+        /// <summary>
+        /// get number of documents in collection
+        /// </summary>
+        /// <returns>number of documents</returns>
+        public Task<long> EstimatedCountAsync()
+        {
+            return Retry(() =>
+            {
+                return Collection.EstimatedDocumentCountAsync();
+            });
+        }
+        #endregion Estimated Count
 
         #endregion Utils
 

--- a/Repository.Mongo/Repository.cs
+++ b/Repository.Mongo/Repository.cs
@@ -5,11 +5,12 @@ using System.Net.Sockets;
 using System.Threading.Tasks;
 using System.Linq.Expressions;
 using System.Collections.Generic;
+// Nuget Microsoft
 using Microsoft.Extensions.Configuration;
-// Polly
+// Nuget Polly
 using Polly;
 using Polly.Retry;
-// MongoDB
+// Nuget MongoDB
 using MongoDB.Driver;
 
 namespace Repository.Mongo

--- a/Repository.Mongo/Repository.cs
+++ b/Repository.Mongo/Repository.cs
@@ -846,63 +846,35 @@ namespace Repository.Mongo
         /// get number of filtered documents
         /// </summary>
         /// <param name="filter">expression filter</param>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCount instead.")]
+        /// <returns>returns the count of documents that match the query for a collection or view.</returns>
         public long Count(Expression<Func<T, bool>> filter)
         {
             return Retry(() =>
             {
-                return Collection.Count(filter);
+                return Collection.CountDocuments(filter);
             });
         }
 
         /// <summary>
-        /// get number of filtered documents
+        /// get number of filtered documents async
         /// </summary>
         /// <param name="filter">expression filter</param>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCountAsync instead.")]
+        /// <returns>returns the count of documents that match the query for a collection or view.</returns>
         public Task<long> CountAsync(Expression<Func<T, bool>> filter)
         {
             return Retry(() =>
             {
-                return Collection.CountAsync(filter);
-            });
-        }
-
-        /// <summary>
-        /// get number of documents in collection
-        /// </summary>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCount instead.")]
-        public long Count()
-        {
-            return Retry(() =>
-            {
-                return Collection.Count(Filter.Empty);
-            });
-        }
-
-        /// <summary>
-        /// get number of documents in collection
-        /// </summary>
-        /// <returns>number of documents</returns>
-        [Obsolete("Use EstimatedCountAsync instead.")]
-        public Task<long> CountAsync()
-        {
-            return Retry(() =>
-            {
-                return Collection.CountAsync(Filter.Empty);
+                return Collection.CountDocumentsAsync(filter);
             });
         }
         #endregion Count
 
         #region EstimatedCount
         /// <summary>
-        /// get number of filtered documents
+        /// get number of all documents in collection
         /// </summary>
         /// <param name="options">count options</param>
-        /// <returns>number of documents</returns>        
+        /// <returns>returns the count of all documents in a collection or view with count options.</returns>        
         public long EstimatedCount(EstimatedDocumentCountOptions options)
         {
             return Retry(() =>
@@ -912,10 +884,10 @@ namespace Repository.Mongo
         }
 
         /// <summary>
-        /// get number of filtered documents
+        /// get number of all documents in collection
         /// </summary>
         /// <param name="options">count options</param>
-        /// <returns>number of documents</returns>        
+        /// <returns>returns the count of all documents in a collection or view with count options.</returns>        
         public Task<long> EstimatedCountAsync(EstimatedDocumentCountOptions options)
         {
             return Retry(() =>
@@ -925,9 +897,9 @@ namespace Repository.Mongo
         }
 
         /// <summary>
-        /// get number of documents in collection
+        /// get number of all documents in collection
         /// </summary>
-        /// <returns>number of documents</returns>
+        /// <returns>returns the count of all documents in a collection or view.</returns>
         public long EstimatedCount()
         {
             return Retry(() =>
@@ -937,9 +909,9 @@ namespace Repository.Mongo
         }
 
         /// <summary>
-        /// get number of documents in collection
+        /// get number of all documents in collection
         /// </summary>
-        /// <returns>number of documents</returns>
+        /// <returns>returns the count of all documents in a collection or view.</returns>
         public Task<long> EstimatedCountAsync()
         {
             return Retry(() =>

--- a/Repository.Mongo/Repository.cs
+++ b/Repository.Mongo/Repository.cs
@@ -145,6 +145,7 @@ namespace Repository.Mongo
         {
             return Collection.Find(Filter.Empty);
         }
+
         #endregion MongoSpecific
 
         #region CRUD
@@ -251,7 +252,7 @@ namespace Repository.Mongo
             });
         }
         #endregion Delete
-
+        
         #region Find
         /// <summary>
         /// find entities
@@ -600,6 +601,22 @@ namespace Repository.Mongo
         }
 
         #endregion Replace
+
+        #region FindOneAndUpdate
+        
+        /// <summary>
+        /// find one and update
+        /// </summary>
+        /// <param name="filter"></param>
+        /// <param name="update"></param>
+        /// <param name="options"></param>
+        /// <returns>return updated entity</returns>
+        public T FindOneAndUpdate(FilterDefinition<T> filter, UpdateDefinition<T> update, FindOneAndUpdateOptions<T> options = null)
+        {
+            return Collection.FindOneAndUpdate(filter, update, options);
+        }
+
+        #endregion FindOneAndUpdate
 
         #region Update
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,34 @@
+# ASP.NET
+# Build and test ASP.NET projects.
+# Add steps that publish symbols, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/aspnet/build-aspnet-4
+
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+
+steps:
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+
+- task: VSBuild@1
+  inputs:
+    solution: '$(solution)'
+    msbuildArgs: '/p:DeployOnBuild=true /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true /p:PackageLocation="$(build.artifactStagingDirectory)"'
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'
+
+- task: VSTest@2
+  inputs:
+    platform: '$(buildPlatform)'
+    configuration: '$(buildConfiguration)'


### PR DESCRIPTION
- Fix BsonClassMap initialization on .NET Core 3.0
- Update MongoDB Driver to 2.9.1
- Add support for BsonDocument $merge
- Bumping NETSTANDARD 1_5 version. Minimum NETSTANDARD version is 2_0
- Update deprecated Count() and CountAsync() methods. Add MongoDriver Estimated methods
- Add Azure DevOps Pipelines Status Badge
- Add FindOneAndUpdate
- Update Readme